### PR TITLE
Fixes Object of type UUID is not JSON serializable

### DIFF
--- a/seleniumlogin/__init__.py
+++ b/seleniumlogin/__init__.py
@@ -9,7 +9,7 @@ def force_login(user, driver, base_url):
     driver.get('{}{}'.format(base_url, selenium_login_start_page))
 
     session = SessionStore()
-    session[SESSION_KEY] = user.id
+    session[SESSION_KEY] = user._meta.pk.value_to_string(user)
     session[BACKEND_SESSION_KEY] = settings.AUTHENTICATION_BACKENDS[0]
     session[HASH_SESSION_KEY] = user.get_session_auth_hash()
     session.save()


### PR DESCRIPTION
Hi there,

I have a user model using an id of type UUID as the primary key for the user.

Trying to use your package I got a json serialization error (`TypeError: Object of type UUID is not JSON serializable`) which is due the direct use of `user.id` as the `session[SESSION_KEY]`.

By looking at the Django 3.2 sources one can find out that the`session[SESSION_KEY]` can be set to `user._meta.pk.value_to_string(user)` which actually solves to issues with django-selenium-login:

1. Primary key can be set to an arbitrary name (e.g. `superid`).
2. Primary key can be of type UUID.

I would be pleased if you accept my PR.