### PR TITLE
fix: Make force_login skip auth backends missing get_user()

### DIFF
--- a/seleniumlogin/__init__.py
+++ b/seleniumlogin/__init__.py
@@ -4,13 +4,22 @@ from django.contrib.auth import SESSION_KEY, BACKEND_SESSION_KEY, HASH_SESSION_K
 
 def force_login(user, driver, base_url):
     from django.conf import settings
+
+    # port from https://github.com/django/django/commit/47744a0a4ed0b9e2d3f52de65abcf6cef9a14e31
+    def get_backend():
+        from django.contrib.auth import load_backend
+        for backend_path in settings.AUTHENTICATION_BACKENDS:
+            backend = load_backend(backend_path)
+            if hasattr(backend, 'get_user'):
+                return backend_path
+
     SessionStore = import_module(settings.SESSION_ENGINE).SessionStore
     selenium_login_start_page = getattr(settings, 'SELENIUM_LOGIN_START_PAGE', '/page_404/')
     driver.get('{}{}'.format(base_url, selenium_login_start_page))
 
     session = SessionStore()
     session[SESSION_KEY] = user._meta.pk.value_to_string(user)
-    session[BACKEND_SESSION_KEY] = settings.AUTHENTICATION_BACKENDS[0]
+    session[BACKEND_SESSION_KEY] = get_backend()
     session[HASH_SESSION_KEY] = user.get_session_auth_hash()
     session.save()
 


### PR DESCRIPTION
fixes https://github.com/feffe/django-selenium-login/issues/1

Porting https://github.com/django/django/commit/47744a0a4ed0b9e2d3f52de65abcf6cef9a14e31

reference [Django ticket](https://code.djangoproject.com/ticket/27542#ticket)